### PR TITLE
Add Pilgrim to open source iOS apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Introspect underlying UIKit components from SwiftUI
 - [AR MultiPendulum](https://github.com/philipturner/ar-multipendulum) - AR app using SwiftUI for touchscreen interface
 - [OakOTP](https://github.com/AlexCatch/Oak) - SwiftUI app for generating OTP codes utilising MVVM, Dependency Injection, Core Data & Cloud Kit
 - [DailyVox](https://github.com/intrepidkarthi/dailyvox) - AI voice diary using SwiftUI with NaturalLanguage, Speech, Core Data, CloudKit. On-device transcription, mood tracking, Digital Twin.
+- [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) - Mindful walking companion with on-device voice transcription, meditation mode, and digital goshuin seals. Full SwiftUI with Combine, CoreStore, WhisperKit, and Live Activities.
 
 ### macOS
 


### PR DESCRIPTION
## Summary

- Adds [Pilgrim](https://github.com/walktalkmeditate/pilgrim-ios) to the open source iOS apps section

Pilgrim is a privacy-first mindful walking companion. It is a full SwiftUI app featuring on-device voice transcription (WhisperKit), guided meditation mode, digital goshuin seals, CoreStore persistence, Mapbox maps, and Live Activities. GPLv3 licensed, free, no accounts, no cloud.

- **GitHub**: https://github.com/walktalkmeditate/pilgrim-ios
- **App Store**: https://apps.apple.com/app/pilgrim-mindful-walking/id6760921056

🤖 Generated with [Claude Code](https://claude.com/claude-code)