### PR TITLE
Add Revu - local-first macOS spaced repetition app

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Introspect underlying UIKit components from SwiftUI
 - [Poirot](https://github.com/LeonardoCardoso/Poirot) - A macOS companion for browsing Claude Code sessions, exploring diffs, and re-running commands. Built with Swift 6, SwiftUI, and the Observation framework.
 - [ClearDisk](https://github.com/bysiber/cleardisk) - Menu bar app to visualize and clean developer caches (Xcode, node_modules, CocoaPods, Docker, pip, Cargo) and reclaim disk space.
 - [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard. Lock/unlock your screen with a hotkey while background tasks keep running.
+- [Revu](https://github.com/JuliusBrussee/revu-swift) - Local-first spaced repetition app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, and study forecasting.
 
 ### MultiPlatform Applications
 


### PR DESCRIPTION
## Summary

Adds [Revu](https://github.com/JuliusBrussee/revu-swift) to the **Open source apps > macOS** section.

Revu is a local-first spaced repetition app for macOS built with SwiftUI. Features include:

- FSRS scheduling algorithm
- Notion-inspired UI
- Anki import
- Study guides, exams, and forecasting

**Website:** https://revu.cards  
**License:** GPL-3.0