### PR TITLE
Add SFSymbolsKit to Icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Introspect underlying UIKit components from SwiftUI
 - [FontAwesomeSwiftUI](https://github.com/onmyway133/FontAwesomeSwiftUI) - Easy to use FontAwesome 5 in SwiftUI
 - [SwiftUIFontIcon](https://github.com/huybuidac/SwiftUIFontIcon) - The easiest way to implement font icons in your SwiftUI project.
 - [SFSafeSymbols](https://github.com/piknotech/SFSafeSymbols) - Safely access Apple's SF Symbols using static typing
+- [SFSymbolsKit](https://github.com/WikipediaBrown/SFSymbolsKit) - Typed String, UIImage, and NSImage APIs for every SF Symbol, generated from Apple's catalog
 
 ### Guide
 


### PR DESCRIPTION
Adds [SFSymbolsKit](https://github.com/WikipediaBrown/SFSymbolsKit) under **Libraries → Image → Icon**, next to the existing SF Symbols entry.

**What it is:** A Swift Package that exposes every SF Symbol as typed `String`, `UIImage`, and `NSImage` properties, plus a `CaseIterable` `SFSymbol` enum. The Swift source is generated deterministically from Apple's symbol list, so it stays complete across SF Symbols releases.

**Why it fits the list / how it differs from SFSafeSymbols (already listed):** SFSafeSymbols focuses on static-typed access to symbol names. SFSymbolsKit additionally ships ready `UIImage`/`NSImage` accessors (UIKit + AppKit) and a generated `CaseIterable` enum for building symbol pickers — a different surface area for SwiftUI/UIKit/AppKit developers.

- MIT licensed, zero dependencies
- iOS 14+, iPadOS, macOS 10.13+, watchOS, tvOS, visionOS
- Documented (https://sfsymbolskit.com) + DocC on Swift Package Index
- CI with a full unit-test suite

Single entry, existing format, alphabetical-ish placement after the related SF Symbols library. Thanks for maintaining the list!