### PR TITLE
Add Dusty to macOS apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Introspect underlying UIKit components from SwiftUI
 - [Privacy Redirect for Safari](https://github.com/smmr-software/privacy-redirect-safari) - Redirect Twitter, YouTube, Reddit, Google Maps, Google Search, and Google Translate to privacy friendly alternatives.
 - [Poirot](https://github.com/LeonardoCardoso/Poirot) - A macOS companion for browsing Claude Code sessions, exploring diffs, and re-running commands. Built with Swift 6, SwiftUI, and the Observation framework.
 - [ClearDisk](https://github.com/bysiber/cleardisk) - Menu bar app to visualize and clean developer caches (Xcode, node_modules, CocoaPods, Docker, pip, Cargo) and reclaim disk space.
+- [Dusty](https://github.com/yagcioglutoprak/dusty) - SwiftUI menu bar cleaner for reclaiming disk space from safe macOS caches, logs, Xcode data, and developer artifacts.
 - [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard. Lock/unlock your screen with a hotkey while background tasks keep running.
 - [Revu](https://github.com/JuliusBrussee/revu-swift) - Local-first spaced repetition app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, and study forecasting.
 


### PR DESCRIPTION
Adds Dusty to the macOS open-source apps section.

Dusty is a native SwiftUI macOS menu bar app for reclaiming disk space from safe caches, logs, Xcode data, and developer artifacts. It fits near ClearDisk in the existing macOS section because both are SwiftUI menu bar utilities focused on developer-cache cleanup and disk-space recovery.

Repository: https://github.com/yagcioglutoprak/dusty