### PR TITLE
Add PermissionPilot to Onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Introspect underlying UIKit components from SwiftUI
 ### Onboarding
 
 - [ConcentricOnboarding](https://github.com/exyte/ConcentricOnboarding) - SwiftUI library for a walkthrough or onboarding flow with tap actions
+- [PermissionPilot](https://github.com/arpitagarwal1301/PermissionPilot) - Drop-in SwiftUI onboarding wizard and macOS permissions flow (detect, prompt, deep-link)
 
 ### Page
 


### PR DESCRIPTION
Adds [PermissionPilot](https://github.com/arpitagarwal1301/PermissionPilot) to the **Onboarding** section.

A drop-in SwiftUI onboarding wizard + macOS permissions flow — detect status, prompt where the OS allows, and deep-link to the exact System Settings pane. Zero third-party dependencies, Apple frameworks only, MIT, macOS 12+.

- Open source: ✅ MIT
- SwiftUI: ✅
- Section: Onboarding