### PR TITLE
Add macOS terminal performance article

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [SwiftUI for Mac ](https://troz.net/post/2019/swiftui-for-mac-1/) - Try out a Mac app and see what happened.
 - [SwiftUI for Mac on Big Sur](https://troz.net/post/2020/swiftui_mac_big_sur/)
 - [AppKit is done](https://kean.blog/post/appkit-is-done) 
+- [Keeping a macOS Terminal UI Responsive During Large SSH Output Bursts](https://nexusshell.hashnode.dev/keeping-a-macos-terminal-ui-responsive-during-large-ssh-output-bursts) - Backpressure and frame-coalesced rendering for a SwiftUI and WebKit terminal.
 
 ## Libraries
 


### PR DESCRIPTION
## Summary

- add one technical article to `Articles > macOS`
- cover backpressure and frame-coalesced rendering in a SwiftUI/WebKit terminal

## Context and disclosure

I develop Nexus Shell, the commercial macOS SSH client whose implementation informed the article. The article is an engineering write-up with Swift and libssh2 examples; it discloses that relationship and includes the product link only for context.

Codex assisted with the README wording and this pull request. I verified the article's technical claims against the implementation.

## Validation

- confirmed the article is publicly accessible
- searched the README and open/closed pull requests for duplicate links
- ran `git diff --check`
