### PR TITLE
Add ItsPaint to Open source apps / macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Introspect underlying UIKit components from SwiftUI
 - [Dusty](https://github.com/yagcioglutoprak/dusty) - SwiftUI menu bar cleaner for reclaiming disk space from safe macOS caches, logs, Xcode data, and developer artifacts.
 - [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard. Lock/unlock your screen with a hotkey while background tasks keep running.
 - [Revu](https://github.com/JuliusBrussee/revu-swift) - Local-first spaced repetition app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, and study forecasting.
+- [ItsPaint](https://github.com/joshlin2201/itspaint) - MS Paint for the Mac. A SwiftUI interface over an AppKit document and canvas, with screenshot markup, step badges, pixelate, and background removal that uses no model.
 
 ### MultiPlatform Applications
 


### PR DESCRIPTION
Adding ItsPaint under **Open source apps → macOS**.

[ItsPaint](https://github.com/joshlin2201/itspaint) is a native Mac paint and markup app: a blank canvas at any size, crop, screenshot markup with numbered step badges and pixelate, and background removal that uses no model. MIT, no third-party dependencies, notarised, and free on the Mac App Store.

On the SwiftUI relevance, since that is what the list is for: the interface, the rail, the panels and the sheets are SwiftUI, hosted in an AppKit `NSDocument` with an `NSView` canvas, because a paint canvas needs direct drawing and precise event handling that SwiftUI does not give you. If that mix is not what the macOS section is collecting, no problem at all and I will close this.

The drawing engine is `Packages/PaintKit`, a UI-free SwiftPM package with no AppKit, no SwiftUI and no dependencies, so `swift test` runs its 288 tests in a fresh clone with no Xcode.
