### PR TITLE
Add Storefront Brief to Newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 - [SwiftUI Weekly](http://weekly.swiftwithmajid.com/) - The curated collection of links about SwiftUI. Delivered every Monday
 - [iOS Dev Weekly](https://iosdevweekly.com/) - Curated by Dave Verwer and published every Friday
 - [iOS Goodies](https://ios-goodies.com/) - weekly iOS newsletter curated by Marius Constantinescu
+- [Storefront Brief](https://fortune-insight.onrender.com/shop/brief/index.html) - English weekly on iOS/indie App Store fees, ASO, and storefront ops ([RSS](https://fortune-insight.onrender.com/shop/brief/feed.xml), [Issue 1](https://fortune-insight.onrender.com/shop/brief/issue-001-en.html))
 
 ### Book
 


### PR DESCRIPTION
Add Storefront Brief to the Newsletter section.

- Archive (homepage): https://fortune-insight.onrender.com/shop/brief/index.html
- Dedicated RSS 2.0: https://fortune-insight.onrender.com/shop/brief/feed.xml
- Issue 1 sample: https://fortune-insight.onrender.com/shop/brief/issue-001-en.html

English weekly on iOS/indie App Store fees, ASO, and storefront ops. Free sample + RSS.

Suggested line (already in this PR):

```
- [Storefront Brief](https://fortune-insight.onrender.com/shop/brief/index.html) - English weekly on iOS/indie App Store fees, ASO, and storefront ops ([RSS](https://fortune-insight.onrender.com/shop/brief/feed.xml), [Issue 1](https://fortune-insight.onrender.com/shop/brief/issue-001-en.html))
```
