### PR TITLE
Add Lyrimuse to Open source apps / macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Introspect underlying UIKit components from SwiftUI
 - [Lockpaw](https://github.com/sorkila/lockpaw) - macOS menu bar screen guard. Lock/unlock your screen with a hotkey while background tasks keep running.
 - [Revu](https://github.com/JuliusBrussee/revu-swift) - Local-first spaced repetition app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, and study forecasting.
 - [ItsPaint](https://github.com/joshlin2201/itspaint) - MS Paint for the Mac. A SwiftUI interface over an AppKit document and canvas, with screenshot markup, step badges, pixelate, and background removal that uses no model.
+- [Lyrimuse](https://github.com/Yudaotor/lyrimuse) - Word-synced desktop lyrics for Apple Music, Spotify and browser web players. SwiftUI overlay, Dynamic Island capsule, lyrics window and menu bar text, with candidates from nine lyric sources scored on one scale to match the right version.
 
 ### MultiPlatform Applications
 


### PR DESCRIPTION
Adding [Lyrimuse](https://github.com/Yudaotor/lyrimuse) under **Open source apps → macOS**.

A SwiftUI desktop-lyrics app for macOS (GPL-3.0): floating overlay, Dynamic-Island-style capsule, an Apple-Music-style lyrics window, and menu bar text — for Apple Music, Spotify, QQ Music, NetEase, Kugou, plus YouTube Music / Spotify Web in a browser. Lyrics candidates from nine providers are scored on one scale so the version actually playing gets the right words.

Built entirely with SwiftUI + SwiftPM (no Xcode project), macOS 14+.