### PR TITLE
Add swift-chat under UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Introspect underlying UIKit components from SwiftUI
 - [GraphKit](https://github.com/Chronaemia/GraphKit) - Graphing library for SwiftUI 
 - [LightChart](https://github.com/pichukov/LightChart) SwiftUI charts
 
+### Chat
+
+- [swift-chat](https://github.com/unionst/swift-chat) - iMessage-faithful chat UI for SwiftUI: bubble tails, typing indicators, read receipts, attachments and keyboard handling in one `Chat` view
+
 ### Color
 
 - [DynamicColor](https://github.com/yannickl/DynamicColor) - Yet another extension to manipulate colors easily in Swift and SwiftUI


### PR DESCRIPTION
Adds a Chat entry under UI for [swift-chat](https://github.com/unionst/swift-chat): an iMessage-faithful chat UI for SwiftUI (iOS 18+) with bubble tails, typing indicators, delivery and read receipts, attachments and interactive keyboard handling in one `Chat` view. Free to use, 1.0 this week. Site: https://swiftchat.app